### PR TITLE
chore(writing): remove windows build from source prompt

### DIFF
--- a/index.html
+++ b/index.html
@@ -17,7 +17,6 @@
     <div id="install">
       <p>Run the following command in your terminal, then follow the onscreen instructions.</p>
       <pre id="cmd"><code>curl -L https://foundry.paradigm.xyz | bash</code></pre>
-      On Windows, <a href="https://book.getfoundry.sh/getting-started/installation.html#building-from-source">build from source</a>.
     </div>
     <p id="help">Need help? Join the <a href="https://t.me/foundry_support">support Telegram</a> or read the <a href="https://book.getfoundry.sh">book</a>.</p>
     <script type="application/javascript">


### PR DESCRIPTION
We now have binaries for windows, so it's not needed to build from source.